### PR TITLE
fix: 修复stepper、slidder中externalClasses js模板语法错误 (#168)

### DIFF
--- a/src/slider/slider.ts
+++ b/src/slider/slider.ts
@@ -27,11 +27,11 @@ type dataType = {
 @wxComponent()
 export default class Slider extends SuperComponent {
   externalClasses = [
-    `${{ prefix }}-class`,
-    `${{ prefix }}-class-bar`,
-    `${{ prefix }}-class-bar-active`,
-    `${{ prefix }}-class-bar-disabled`,
-    `${{ prefix }}-class-cursor`,
+    `${prefix}-class`,
+    `${prefix}-class-bar`,
+    `${prefix}-class-bar-active`,
+    `${prefix}-class-bar-disabled`,
+    `${prefix}-class-cursor`,
   ];
 
   properties = props;

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -7,10 +7,10 @@ const { prefix } = config;
 @wxComponent()
 export default class Stepper extends SuperComponent {
   externalClasses = [
-    `${{ prefix }}-class`,
-    `${{ prefix }}-class-input`,
-    `${{ prefix }}-class-minus`,
-    `${{ prefix }}-class-plus`,
+    `${prefix}-class`,
+    `${prefix}-class-input`,
+    `${prefix}-class-minus`,
+    `${prefix}-class-plus`,
   ];
 
   options = {


### PR DESCRIPTION
Co-authored-by: walker <oncwnuE2xYmYovsYRZyfDvyz_nWU@git.weixin.qq.com>